### PR TITLE
Fix ViViD compatibility with KlipperScreen API rename

### DIFF
--- a/KlipperScreen/vivid/controllers/mms.py
+++ b/KlipperScreen/vivid/controllers/mms.py
@@ -13,13 +13,48 @@ class ViViDKey:
     heater: str = "heater_generic ViViD_Dryer"
 
 
+def get_klippy_api(screen):
+    """Get the Moonraker API object from a KlipperScreen window.
+
+    KlipperScreen renamed `_ws.klippy` to `_ws.api`; return whichever
+    attribute exists so the same code works on both versions.
+    """
+    return (getattr(screen._ws, 'klippy', None)
+            or getattr(screen._ws, 'api', None))
+
+
+def get_rest_client(screen):
+    """Get the KlippyRest client from a KlipperScreen window.
+
+    KlipperScreen renamed `screen.apiclient` to `screen.restApi`; return
+    whichever attribute exists so the same code works on both versions.
+    """
+    return (getattr(screen, 'apiclient', None)
+            or getattr(screen, 'restApi', None))
+
+
 class MMSController:
     def __init__(self, screen):
         self._screen = screen
-        self._klippy = self._screen._ws.klippy
-        # "client" should be KlippyRest() in ks_includes/KlippyRest.py
-        # Or get it with ScreenPanel._screen.apiclient
-        self._client = self._screen.apiclient
+        # self._klippy = self._screen._ws.klippy
+        # # "client" should be KlippyRest() in ks_includes/KlippyRest.py
+        # # Or get it with ScreenPanel._screen.apiclient
+        # self._client = self._screen.apiclient
+        try:
+            self._klippy = get_klippy_api(self._screen)
+            self._client = get_rest_client(self._screen)
+            if self._klippy is None or self._client is None:
+                missing = []
+                if self._klippy is None:
+                    missing.append("_ws.klippy/_ws.api")
+                if self._client is None:
+                    missing.append("screen.apiclient/screen.restApi")
+                raise RuntimeError(
+                    f"MMSController: missing KlipperScreen API "
+                    f"dependencies: {', '.join(missing)}")
+        except Exception as e:
+            logging.exception(f"MMSController initialization failed: {e}")
+            raise
 
         self.method = "printer/objects/query?mms"
 

--- a/KlipperScreen/vivid/panels/main.py
+++ b/KlipperScreen/vivid/panels/main.py
@@ -93,7 +93,7 @@ class Panel(ScreenPanel):
         self.content.add(main_grid)
 
     def send_klippy_script(self, script):
-        self._screen._ws.klippy.gcode_script(script)
+        self.mms_controller.send_script(script)
 
     # ---- Section Creation Methods ----
     def create_slot_area(self):

--- a/KlipperScreen/vivid/panels/preprint.py
+++ b/KlipperScreen/vivid/panels/preprint.py
@@ -7,6 +7,7 @@ from gi.repository import Gtk
 
 from ks_includes.screen_panel import ScreenPanel
 
+from vivid.controllers.mms import get_klippy_api
 from vivid.config.manager import VividConfigManager
 from vivid.components.box import (
     FixedSquareBox, 
@@ -375,7 +376,7 @@ class Panel(ScreenPanel):
         for swap_num, slot_num in self.mapping_pairs:
             # Filename could have " ", so use \"\" to avoid error
             script = f"MMS_SWAP_MAPPING SWAP_NUM={swap_num} SLOT={slot_num} FILENAME=\"{self.gf_filename}\""
-            self._screen._ws.klippy.gcode_script(script)
+            get_klippy_api(self._screen).gcode_script(script)
 
 
 def parse_filament_colors(

--- a/KlipperScreen/vivid/panels/slot.py
+++ b/KlipperScreen/vivid/panels/slot.py
@@ -6,6 +6,7 @@ from gi.repository import Gtk
 
 from ks_includes.screen_panel import ScreenPanel
 
+from vivid.controllers.mms import get_klippy_api, get_rest_client
 from vivid.config.vivid_config import ColorConfig, VividConfig
 from vivid.components.box import FixedSquareBox
 from vivid.components.button import (
@@ -178,7 +179,7 @@ class Panel(ScreenPanel):
 
         # Sync to Klipper
         script = f"MMS_SLOT_MAP SLOT={self.slot_num} MATERIAL='{material}'"
-        self._screen._ws.klippy.gcode_script(script)
+        get_klippy_api(self._screen).gcode_script(script)
 
     # ---- Color Palette Components ----
     def create_color_palette(self):
@@ -244,7 +245,7 @@ class Panel(ScreenPanel):
         color_hex = new_color[1:] if new_color.startswith("#") else new_color
         color_hex = color_hex.lower()
         script = f"MMS_SLOT_MAP SLOT={self.slot_num} COLOR='{color_hex}'"
-        self._screen._ws.klippy.gcode_script(script)
+        get_klippy_api(self._screen).gcode_script(script)
 
         # Update hardware LED color
         self.mms_update_slot_led(new_color)
@@ -255,7 +256,7 @@ class Panel(ScreenPanel):
         color_hex = color[1:] if color.startswith("#") else color
         color_hex = color_hex.lower()
         script = f"MMS_LED_SET_COLOR SLOT={self.slot_num} COLOR={color_hex}"
-        self._screen._ws.klippy.gcode_script(script)
+        get_klippy_api(self._screen).gcode_script(script)
 
     # ---- SLOT Control Functions ----
     def create_slot_control(self, slot_num, color):
@@ -375,7 +376,7 @@ class Panel(ScreenPanel):
         return str(value)
 
     def _get_lane_data(self):
-        client = getattr(self._screen, "apiclient", None)
+        client = get_rest_client(self._screen)
         if not client:
             return None
         lane_result = client.send_request("server/database/item?namespace=lane_data")
@@ -388,7 +389,7 @@ class Panel(ScreenPanel):
         return slot_data if isinstance(slot_data, dict) else None
 
     def _get_mms_metadata(self):
-        client = getattr(self._screen, "apiclient", None)
+        client = get_rest_client(self._screen)
         if not client:
             return None
         # Query Klipper directly for mms object status
@@ -578,11 +579,11 @@ class Panel(ScreenPanel):
             f" NOZZLE_TEMP={nozzle_temp if nozzle_temp else empty_str}"
             f" BED_TEMP={bed_temp if bed_temp else empty_str}"
         )
-        self._screen._ws.klippy.gcode_script(script)
+        get_klippy_api(self._screen).gcode_script(script)
 
     def mms_slot_action(self, script):
         """Execute GCode command for slot action"""
-        self._screen._ws.klippy.gcode_script(script)
+        get_klippy_api(self._screen).gcode_script(script)
 
     # ---- Panel life ----
     def activate(self):


### PR DESCRIPTION
KlipperScreen renamed KlippyWebsocket.klippy to api and screen.apiclient to restApi. The ViViD extension still accessed the old names directly in several places, which breaks on the latest KlipperScreen (see Klipper forum
(https://klipper.discourse.group/t/klipper-screen-error-with-biqu-vvd-menu/26199/7)).

Changes:

- Add get_klippy_api() / get_rest_client() compatibility helpers in vivid/controllers/mms.py
- Route all direct _ws.klippy / apiclient accesses in panels through the helpers
- MMSController now fails fast with a clear error if the KlipperScreen API dependencies are missing

Verified working against both old (klippy/apiclient) and new (api/restApi) naming.